### PR TITLE
Add 404 page and list of all pages

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,10 @@
+---
+permalink: 404.html
+---
+
+# Uh-oh!
+
+## Error: 404 Page not found.
+
+We couldn't find the page you're looking for! It may have moved or something, check the [List of all Pages](list-of-all-pages).
+

--- a/list-of-all-pages.md
+++ b/list-of-all-pages.md
@@ -1,0 +1,58 @@
+# List of All Pages
+
+A list of all wiki pages in the RoseSMP wiki, listed in alphabetical order.
+
+### A
+
+### B
+
+### C
+
+### D
+
+### E
+
+### F
+
+### G
+
+### H
+
+### I
+
+### J
+
+### K
+
+### L
+
+### M
+
+ - [Matt Rose](matt-rose)
+
+### N
+
+### O
+
+### P
+
+### Q
+
+### R
+
+### S
+
+### T
+
+### U
+
+### V
+
+### W
+
+### X
+
+### Y
+
+### Z
+


### PR DESCRIPTION
added a 404 page according to the [github docs](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site), and added a wiki page to list all pages